### PR TITLE
chore(dependabot): raise semver-patch cooldown to 5 days [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       timezone: "Asia/Amman"
     cooldown:
       default-days: 3
-      semver-patch-days: 1
+      semver-patch-days: 5
       semver-minor-days: 3
       semver-major-days: 7
     open-pull-requests-limit: 10
@@ -36,7 +36,7 @@ updates:
       timezone: "Asia/Amman"
     cooldown:
       default-days: 3
-      semver-patch-days: 1
+      semver-patch-days: 5
       semver-minor-days: 3
       semver-major-days: 7
     open-pull-requests-limit: 5


### PR DESCRIPTION
chore(dependabot): raise semver-patch cooldown to 5 days

Patch is the only update class that auto-merges with no human
involved, yet carried the shortest cooldown (1 day, a third of
GitHub's 3-day default). Soak time should scale with how little
scrutiny a bump receives, not with how breaking semver claims it is.

Costs nothing in security terms: cooldown never applies to Dependabot
security updates, which still fire immediately.

Propagated from simplify9/.github (dependabot-templates).
